### PR TITLE
Enable cache headers in kartotherian sources

### DIFF
--- a/kartotherian/sources.yaml
+++ b/kartotherian/sources.yaml
@@ -19,6 +19,8 @@ oz:
   uri: overzoom://
   params:
     source: {ref: v2}
+  defaultHeaders:
+    Cache-Control: 'public, max-age=3600, s-maxage=3600'
 
 # Final raster source
 osm-intl:  # This name is the default Kartotherian leaflet test app layer name
@@ -55,3 +57,5 @@ oz-lite:
   uri: overzoom://
   params:
     source: {ref: v2-lite}
+  defaultHeaders:
+    Cache-Control: 'public, max-age=3600, s-maxage=3600'

--- a/kartotherian/sources.yaml
+++ b/kartotherian/sources.yaml
@@ -12,6 +12,7 @@ v2:
     repfactor: 4
     durablewrite: 0
     createIfMissing: true
+    setLastModified: true
 
 oz:
   public: true
@@ -50,6 +51,7 @@ v2-lite:
     repfactor: 4
     durablewrite: 0
     createIfMissing: true
+    setLastModified: true
 
 oz-lite:
   public: true


### PR DESCRIPTION
`Cache-Control` is set explicitly for each source (1 hour for the moment).

`Last-Modified` is implemented in https://github.com/QwantResearch/cassandra/pull/1 (using date when tile was written in Cassandra).