### PR TITLE
create wikidata table and clean setup

### DIFF
--- a/import_data/tasks.py
+++ b/import_data/tasks.py
@@ -40,13 +40,6 @@ def run_sql_script(ctx):
     # load several psql functions
     _run_sql_script(ctx, "language.sql")
     _run_sql_script(ctx, "postgis-vt-util.sql")
-    # localization sql function
-    _run_sql_script(ctx, "get_localized_name.sql")
-    _run_sql_script(ctx, "get_localized_name_from_tags.sql")
-    _run_sql_script(ctx, "get_country.sql")
-    _run_sql_script(ctx, "get_country_name.sql")
-    _run_sql_script(ctx, "geo_transliterate.sql")
-
 
 @task
 def import_natural_earth(ctx):
@@ -128,8 +121,8 @@ def import_wikidata(ctx):
 
     For the moment this does nothing (but we need a table for some openmaptiles function)
     """
-    create_table = "CREATE TABLE IF NOT EXISTS wd_names (id          varchar(20) UNIQUE, page          varchar(200) UNIQUE,    labels      hstore);"
-    ctx.run(f"psql -Xq -h {ctx.pg.host} -U {ctx.pg.user} -d {ctx.pg.database} {create_table}",
+    create_table = "CREATE TABLE IF NOT EXISTS wd_names (id varchar(20) UNIQUE, page varchar(200) UNIQUE, labels hstore);"
+    ctx.run(f'psql -Xq -h {ctx.pg.host} -U {ctx.pg.user} -d {ctx.pg.database} -c "{create_table}"',
             env={'PGPASSWORD': ctx.pg.password})
 
 

--- a/import_data/tasks.py
+++ b/import_data/tasks.py
@@ -122,6 +122,18 @@ def import_border(ctx):
 
 
 @task
+def import_wikidata(ctx):
+    """
+    import wikidata (for some translations)
+
+    For the moment this does nothing (but we need a table for some openmaptiles function)
+    """
+    create_table = "CREATE TABLE IF NOT EXISTS wd_names (id          varchar(20) UNIQUE, page          varchar(200) UNIQUE,    labels      hstore);"
+    ctx.run(f"psql -Xq -h {ctx.pg.host} -U {ctx.pg.user} -d {ctx.pg.database} {create_table}",
+            env={'PGPASSWORD': ctx.pg.password})
+
+
+@task
 def run_post_sql_scripts(ctx):
     """
     load the sql file with all the functions to generate the layers
@@ -145,6 +157,7 @@ def load_additional_data(ctx):
     import_water_polygon(ctx)
     import_lake(ctx)
     import_border(ctx)
+    import_wikidata(ctx)
 
 
 @task(default=True)


### PR DESCRIPTION
* create empty wikidata table
the wikidata table is used by openmaptiles for some translation.
for the moment we do not import those data, but we need the table for the openmaptiles scripts

* do not run osml10n script 
those scripts are run because they are part of the extension osml10n, so
we don't need to run them twice
