### PR TITLE
kartotherian: Update sources.yaml to use cassandra as read-only

### DIFF
--- a/kartotherian/sources.yaml
+++ b/kartotherian/sources.yaml
@@ -8,9 +8,7 @@ v2-lite:
     cp: {var: cassandra-servers}
     username: {var: cassandra-user}
     password: {var: cassandra-pswd}
-    repfactor: 4
-    durablewrite: 0
-    createIfMissing: true
+    createIfMissing: false
     setLastModified: true
 
 oz-lite:
@@ -33,9 +31,7 @@ basemap:
     cp: {var: cassandra-servers}
     username: {var: cassandra-user}
     password: {var: cassandra-pswd}
-    repfactor: 4
-    durablewrite: 0
-    createIfMissing: true
+    createIfMissing: false
     setLastModified: true
 
 ozbasemap:
@@ -59,9 +55,7 @@ poi:
     cp: {var: cassandra-servers}
     username: {var: cassandra-user}
     password: {var: cassandra-pswd}
-    repfactor: 4
-    durablewrite: 0
-    createIfMissing: true
+    createIfMissing: false
     setLastModified: true
 
 ozpoi:

--- a/update/readme.md
+++ b/update/readme.md
@@ -1,5 +1,0 @@
-bash script to update the osm data with diffs
-
-if the script is run behind a proxy you need to set them for osmosis:
-
-`JAVACMD_OPTIONS="-Dhttp.proxyHost=<proxy> -Dhttp.proxyPort=<port> -Dhttps.proxyHost=<proxy> -Dhttps.proxyPort=<port>" osm_update.sh`


### PR DESCRIPTION
This new configuration will be required to upgrade kartotherian,  
see: https://github.com/QwantResearch/kartotherian/pull/3