### PR TITLE
Remove swimming pool

### DIFF
--- a/imposm/generated_mapping_poi.yaml
+++ b/imposm/generated_mapping_poi.yaml
@@ -22,8 +22,8 @@ tables:
         embassy, fast_food, ferry_terminal, fire_station, food_court, fuel, grave_yard,
         hospital, ice_cream, kindergarten, library, marketplace, nightclub, nursing_home,
         pharmacy, place_of_worship, police, post_box, post_office, prison, pub, public_building,
-        recycling, restaurant, school, shelter, swimming_pool, taxi, telephone, theatre,
-        toilets, townhall, university, veterinary, waste_basket]
+        recycling, restaurant, school, shelter, taxi, telephone, theatre, toilets,
+        townhall, university, veterinary, waste_basket]
       barrier: &id003 [bollard, border_control, cycle_barrier, gate, lift_gate, sally_port,
         stile, toll_booth]
       highway: &id004 [bus_stop]
@@ -31,7 +31,7 @@ tables:
       landuse: &id006 [basin, brownfield, cemetery, reservoir]
       leisure: &id007 [dog_park, escape_game, garden, golf_course, ice_rink, hackerspace,
         marina, miniature_golf, park, pitch, playground, sports_centre, stadium, swimming_area,
-        swimming_pool, water_park]
+        water_park]
       railway: &id008 [halt, station, subway_entrance, train_station_entrance, tram_stop]
       shop: &id009 [accessories, alcohol, antiques, art, bag, bakery, beauty, bed,
         beverages, bicycle, books, boutique, butcher, camera, car, car_repair, carpet,


### PR DESCRIPTION
This is nothing more than an update of the generated mappings from openmaptiles-tools after removing swimming pools from the yaml config files in https://github.com/QwantResearch/openmaptiles/pull/13