### PR TITLE
Improve documentation for outsiders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
 # Configuration files for kartotherian stack
 
+## Cloning this repository
+
+Make sure to clone the submodules as well
+
+```
+git clone --recurse-submodules https://github.com/QwantResearch/kartotherian_config
+```
+
+## import_data
+
+This folder contains all the scripts and details to import OSM (and Natural
+Earth) data into a PostgreSQL database.
+
 ## Imposm
 
- * `imposm3_mapping.yml` : Imposm mapping (based on openmaptiles)
- * `generated_sql.sql` : SQL views, functions and triggers used by vector style
+ * `generated_mapping_{base,poi}.yml` : Imposm mapping (based on openmaptiles) for basemap and POIs
+ * `generated_{base,poi}.sql` : SQL views, functions and triggers used by vector style
 
 ## Tilerator
 

--- a/import_data/invoke.yaml
+++ b/import_data/invoke.yaml
@@ -7,8 +7,8 @@ pg:
   password: gis
   port: 5432
 
-main_dir: /srv/import_data
-sql_dir: /srv/import_data/sql
+main_dir: ../imposm
+sql_dir: ../imposm
 
 generated_files_dir: /data/imposm
 data_dir: /data

--- a/import_data/readme.md
+++ b/import_data/readme.md
@@ -18,6 +18,9 @@ or to use an already downloaded file:
 
 `INVOKE_OSM_FILE=path_to_an_osm_file pipenv run invoke`
 
+Generated data will be stored in a `/data` folder so you should make sure this
+folder exists and is writable prior to running the import.
+
 Note:
 the osm file can also be put in a `invoke.yaml` file.
 
@@ -29,3 +32,5 @@ eg.
 `INVOKE_OSM_FILE=path_to_an_osm_file pipenv run invoke load-poi`
 
 Note: be careful to replace `_` with `-` in the function name
+
+Note: the `pipenv` command should be ran from the `import_data` folder.

--- a/import_data/tasks.py
+++ b/import_data/tasks.py
@@ -157,8 +157,8 @@ def _run_sql_script(ctx, script_name):
 @task
 def run_sql_script(ctx):
     # load several psql functions
-    _run_sql_script(ctx, "language.sql")
-    _run_sql_script(ctx, "postgis-vt-util.sql")
+    _run_sql_script(ctx, "../external_dependencies/import-sql/language.sql")
+    _run_sql_script(ctx, "../external_dependencies/postgis-vt-util/postgis-vt-util.sql")
 
 
 @task
@@ -207,7 +207,7 @@ def import_water_polygon(ctx):
     ctx.run(
         f"POSTGRES_PASSWORD={ctx.pg.password} POSTGRES_PORT={ctx.pg.port} IMPORT_DATA_DIR={ctx.data_dir} \
   POSTGRES_HOST={ctx.pg.host} POSTGRES_DB={ctx.pg.import_database} POSTGRES_USER={ctx.pg.user} \
-  {ctx.main_dir}/import-water.sh"
+  {ctx.main_dir}/../external_dependencies/import-water/import-water.sh"
     )
 
 
@@ -250,7 +250,7 @@ def import_border(ctx):
     ctx.run(
         f"POSTGRES_PASSWORD={ctx.pg.password} POSTGRES_PORT={ctx.pg.port} IMPORT_DIR={ctx.data_dir} \
   POSTGRES_HOST={ctx.pg.host} POSTGRES_DB={ctx.pg.import_database} POSTGRES_USER={ctx.pg.user} \
-  {ctx.main_dir}/import_osmborder_lines.sh"
+  {ctx.main_dir}/../external_dependencies/import-osmborder/import/import_osmborder_lines.sh"
     )
 
 

--- a/tilerator/readme.md
+++ b/tilerator/readme.md
@@ -1,0 +1,6 @@
+# Tilerator
+
+This is the tilerator configuration. Prior to using it, you should:
+
+* Check and update your PostgreSQL credentials in the `data_tm2source_*.yml` files.
+* Update the paths to YAML files in the `sources.yaml` file.


### PR DESCRIPTION
Hi,

First of all, thanks a lot for sharing all of these scripts and documentation! It's really a super useful tool to get started with serving OpenMapTiles!

I spotted some default values which could probably be clearer for an outsider having a look at it. Not sure if this is fine for a merge?

The changes I propose are about:
* Reworking and completing a bit the documentation.
* Loading the SQL scripts from the submodules directly, as this seems a better and safer default value.
* Set `main_dir` and `sql_dir` to safe default values.
* Add a README for the Tilerator configuration.

Let me know if this PR needs any rework before merge.
Best!